### PR TITLE
Updates the project readme with steps to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@
 This project provides a local development environment for developers to work
 with our exhibit-building tool, [Omeka S](https://omeka.org/s/).
 
+## Using this repository
+
+Getting your local Omeka S instance running via this repository should be a
+straightforward process:
+
+1. Clone this repository
+
+2. Run `install.sh`
+
+3. Visit https://mit-libraries-exhibits.lndo.site to finish the process.
+
+This will include defining the first user account.
+
 ## Resources
 
 Here are a list of resources I've consulted to make progress on this effort:

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# This script attempts to automate the steps described at
+# https://github.com/omeka/omeka-s#installing-from-github
+
 # Check dependencies
 echo "Lando version:"
 lando version
@@ -9,13 +12,15 @@ echo "NPM version:"
 npm -v
 
 # Clone and build the Omeka codebase
+# TODO: accept a parameter for checking out a specific tag
 git clone https://github.com/omeka/omeka-s.git web
 cd web
 npm install
 npx gulp init
+cd ..
 
 # Overwrite the blank database.ini with values for Lando
-cp ../database.lando.ini ./config/database.ini
+cp database.lando.ini web/config/database.ini
 
 # Start the application
 lando start


### PR DESCRIPTION
** Why are these changes being introduced:

* 

** How does this address that need:


** Document any side effects to this change:


### Why these changes are being introduced

The steps to follow to use this repository should be described in the project readme.

Additionally, the install script itself is a bit wonky, ending the user in a different directory from when they start.

### How this addresses that need

This updates the project readme to describe the steps that the user should follow to install Omeka S.

This also updates the install script to leave the user in the same directory where they started.

### Side effects of this change

Because we change directories now, the copying of the database credentials gets updated to be more logical.

This also adds more comments to the script, citing sources and leaving a todo for future work.

### Relevant ticket(s)

n/a