### PR TITLE
Bump PHP version to 8.2

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,7 +1,7 @@
 name: mit-libraries-exhibits
 recipe: lamp
 config:
-  php: '7.4'
+  php: '8.2'
   webroot: web
   database: 'mysql:5.7'
   xdebug: false


### PR DESCRIPTION
### Why are these changes being introduced:

We are using PHP 8.2 on our production and staging instances, so our local environment should match it.

### Relevant ticket(s):

n/a

### How does this address that need:

This bumps the PHP version in the .lando.yml file to 8.2. Folks who who have already set up a local Omeka instance should use complete their upgrade by running `lando rebuild`. This command will preserve any local data you've created.

### Document any side effects to this change:

None
